### PR TITLE
change zoomCrop to use force

### DIFF
--- a/Image.php
+++ b/Image.php
@@ -392,7 +392,7 @@ class Image
      *
      * @return void
      */
-    private function _zoomCrop($width, $height)
+    private function _zoomCrop($width, $height, $bg = 0xffffff)
     {
         // Calculate the different ratios
         $originalRatio = imagesx($this->gd) / imagesy($this->gd);
@@ -410,7 +410,7 @@ class Image
         }
 
         // Perform resize
-        $this->_resize($newWidth, $newHeight);
+        $this->_resize($newWidth, $newHeight, $bg, true);
 
         // Calculate cropping area
         $xPos = (int) ($newWidth - $width) / 2;

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ The methods available are:
 
 * `circle($cx, $cy, $r, $color, $filled=false)`: draws a circle
 
-* `zoomCrop($width, $height)`: resize and crop the image to fit to given dimensions
+* `zoomCrop($width, $height, $background)`: resize and crop the image to fit to given dimensions
 
 You can also create image from scratch using:
 


### PR DESCRIPTION
I was having an issue where zoomCrop would produce an image with a 1px white strip on the bottom edge when using odd numbered dimensions, this seems to fix it
