### PR TITLE
Change _crop to keep transparency

### DIFF
--- a/Image.php
+++ b/Image.php
@@ -582,6 +582,8 @@ class Image
      */
     public function _crop($x, $y, $w, $h) {
         $dst = imagecreatetruecolor($w, $h);
+        imagealphablending($dst, false);
+        imagesavealpha($dst, true);
         imagecopy($dst, $this->gd, 0, 0, $x, $y, imagesx($this->gd), imagesy($this->gd));
         imagedestroy($this->gd);
         $this->gd = $dst;


### PR DESCRIPTION
Fix for the problem i was having while using _zoomCrop on png with transparency.
See issue #18 for details.
