### PR TITLE
Add "use" statement to load correct class

### DIFF
--- a/Adapter/GD.php
+++ b/Adapter/GD.php
@@ -3,6 +3,7 @@
 namespace Gregwar\Image\Adapter;
 
 use Gregwar\Image\ImageColor;
+use Gregwar\Image\Image;
 
 class GD extends Common
 {


### PR DESCRIPTION
This prevents errors of the type "Argument 1 passed to Gregwar\Image\Adapter\GD::merge() must be an instance of Gregwar\Image\Adapter\Image, instance of Gregwar\Image\Image given" caused by Gregwar\Image\Adapter\GD looking in the same folder for the Image class in all methods with an "Image" typehint
