### PR TITLE
Fix Orientation of image

### DIFF
--- a/Adapter/GD.php
+++ b/Adapter/GD.php
@@ -509,4 +509,28 @@ class GD extends Common
 
 		return $this;
 	}
+	
+	
+ 	public function fixOrientation()
+ 	{
+        if (!extension_loaded('exif')) {
+            throw new \RuntimeException('You need to EXIF PHP Extension to use this function');
+        }
+        $exif = exif_read_data($this->source->getInfos());
+        if (!empty($exif['Orientation'])) {
+            switch ($exif['Orientation']) {
+                case 3:
+                    $this->resource = imagerotate($this->resource, 180, 0);
+                    break;
+                case 6:
+                    $this->resource = imagerotate($this->resource, -90, 0);
+                    break;
+                case 8:
+                    $this->resource = imagerotate($this->resource, 90, 0);
+                    break;
+            }
+        }
+        return $this;
+    }
+
 }


### PR DESCRIPTION
Some images has orientation property in them. If you click a image in portrait and try to re-size it, it change it's orientation to landscape and then re-size properties are applied   

More info here http://www.impulseadventure.com/photo/exif-orientation.html

Live photo to test: http://bit.ly/1fINknK ( apply resize operation on this image )

Function require exif extension.
Use
`echo Image::open('photo.JPG')->fixOrientation()->zoomCrop(200,200)->html();`