### PR TITLE
Correcting required: gregwar/cache dependency version for composer insta...

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "gregwar/cache": "1.0.7",
+        "gregwar/cache": "1.*",
         "php": ">=5.3.0",
         "ext-gd": "*"
     },


### PR DESCRIPTION
Corrected the composer version attribute for "gregwar/cache", was "v1.0.7" which did not follow the composer configuration rules (https://getcomposer.org/doc/04-schema.md#version) and caused automatic installation with composer to stop with error.
