### PR TITLE
added a check with getimagesize

### DIFF
--- a/ImageColor.php
+++ b/ImageColor.php
@@ -18,7 +18,7 @@ class ImageColor
         'green'     =>  0x008000,
         'lime'      =>  0x00ff00,
         'white'     =>  0xffffff,
-        'fuschia'   =>  0xff00ff,
+        'fuchsia'   =>  0xff00ff,
         'purple'    =>  0x800080,
         'olive'     =>  0x808000,
         'yellow'    =>  0xffff00,

--- a/Source/File.php
+++ b/Source/File.php
@@ -28,22 +28,25 @@ class File extends Source
 
     public function guessType()
     {
+        $validTypes = array(
+            IMAGETYPE_GIF  => 'gif',
+            IMAGETYPE_PNG  => 'png',
+            IMAGETYPE_JPEG => 'jpeg'
+        );
+
         if (function_exists('exif_imagetype')) {
             $type = @exif_imagetype($this->file);
+        }
+        elseif (function_exists('getimagesize')) {
+            $info = @getimagesize($this->file);
+            $type = is_array($info) && isset($info[2]) ? $info[2] : false;
+        }
+        else {
+            $type = false;
+        }
 
-            if (false !== $type) {
-                if ($type == IMAGETYPE_JPEG) {
-                    return 'jpeg';
-                }
-
-                if ($type == IMAGETYPE_GIF) {
-                    return 'gif';
-                }
-
-                if ($type == IMAGETYPE_PNG) {
-                    return 'png';
-                }
-            }
+        if (false !== $type && isset($validTypes[$type])) {
+            return $validTypes[$type];
         }
 
         $parts = explode('.', $this->file);


### PR DESCRIPTION
If `exif_imagetype` is not available one can use `getimagesize` before guessing with the `fileextension`
