### PR TITLE
PHP 7 as a required test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,6 @@ php:
     - 5.6
     - 7.0
 
-matrix:
-    allow_failures:
-        - php: 7.0
-
 script:
     - composer install
     - phpunit


### PR DESCRIPTION
Tests are working with PHP 7, let make it mandatory.