### PR TITLE
When loading a file check that it's actually a file

### DIFF
--- a/Adapter/Common.php
+++ b/Adapter/Common.php
@@ -172,8 +172,8 @@ abstract class Common extends Adapter
 
     protected function loadFile($file, $type)
     {
-        if(!is_file($file)){
-            throw new \UnexpectedValueException($file.' is not a file)');
+        if (!is_file($file)) {
+            throw new \UnexpectedValueException($file . ' is not a file)');
         }
         
         if (!$this->supports($type)) {

--- a/Adapter/Common.php
+++ b/Adapter/Common.php
@@ -173,9 +173,9 @@ abstract class Common extends Adapter
     protected function loadFile($file, $type)
     {
         if (!is_file($file)) {
-            throw new \UnexpectedValueException($file . ' is not a file)');
+            throw new \UnexpectedValueException($file.' is not a file)');
         }
-        
+
         if (!$this->supports($type)) {
             throw new \RuntimeException('Type '.$type.' is not supported by GD');
         }

--- a/Adapter/Common.php
+++ b/Adapter/Common.php
@@ -172,6 +172,10 @@ abstract class Common extends Adapter
 
     protected function loadFile($file, $type)
     {
+        if(!is_file($file)){
+            throw new \UnexpectedValueException($file.' is not a file)');
+        }
+        
         if (!$this->supports($type)) {
             throw new \RuntimeException('Type '.$type.' is not supported by GD');
         }

--- a/tests/ImageTests.php
+++ b/tests/ImageTests.php
@@ -259,6 +259,16 @@ class ImageTests extends \PHPUnit_Framework_TestCase
         $this->assertTrue(file_exists($error));
     }
 
+    public function testDirectoryAsFilepath()
+    {
+        $jpg = $this->output('a.jpg');
+        $img = $this->open('.')
+            ->negate();
+        $error = $img->save($jpg);
+
+        $this->assertTrue(file_exists($error));
+    }
+
     /**
      * * @expectedException              \UnexpectedValueException
      */
@@ -438,7 +448,7 @@ class ImageTests extends \PHPUnit_Framework_TestCase
      */
     protected function output($file)
     {
-        return __DIR__.'/output/'.$file;
+        return __DIR__.DIRECTORY_SEPARATOR.'output'.DIRECTORY_SEPARATOR.$file;
     }
 
     /**
@@ -447,7 +457,13 @@ class ImageTests extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         $dir = $this->output('');
-        `rm -rf $dir`;
+
+        if (stristr(PHP_OS, 'WIN')) {
+            `rd /s /q $dir`;
+        } else {
+            `rm -rf $dir`;
+        }
+
         mkdir($dir);
         mkdir($this->output('cache'));
     }


### PR DESCRIPTION
When loading a file, we check that the resource is actually a file, as it breaks when calling a directory. Fixes issue #97.
