### PR TITLE
Update autoload.php

### DIFF
--- a/autoload.php
+++ b/autoload.php
@@ -2,7 +2,7 @@
 
 $vendors = __DIR__.'/vendor/autoload.php';
 if (file_exists($vendors)) {
-    require $vendors;
+    return require $vendors;
 }
 
 /*


### PR DESCRIPTION
don't setup two autoloaders

assuming vendor/autoload.php is composer generated, then can just return the autoloader object