### PR TITLE
Silence EXIF errors

### DIFF
--- a/Adapter/Common.php
+++ b/Adapter/Common.php
@@ -99,7 +99,7 @@ abstract class Common extends Adapter
             throw new \RuntimeException('You need to EXIF PHP Extension to use this function');
         }
 
-        $exif = exif_read_data($this->source->getInfos());
+        $exif = @exif_read_data($this->source->getInfos());
 
         if (!array_key_exists('Orientation', $exif)) {
             return $this;


### PR DESCRIPTION
Don't break the entire resize operation, for one small EXIF error, which may not even stop us from rotating the image.

Fixes issues #92 and #96