### PR TITLE
Only process fixOrientation if the image is jpg/tiff

### DIFF
--- a/Adapter/Common.php
+++ b/Adapter/Common.php
@@ -95,6 +95,10 @@ abstract class Common extends Adapter
      */
     public function fixOrientation()
     {
+        if (!in_array(exif_imagetype($this->source->getInfos()), [IMAGETYPE_JPEG, IMAGETYPE_TIFF_II, IMAGETYPE_TIFF_MM])) {
+            return $this;
+        }
+        
         if (!extension_loaded('exif')) {
             throw new \RuntimeException('You need to EXIF PHP Extension to use this function');
         }

--- a/Adapter/Common.php
+++ b/Adapter/Common.php
@@ -95,10 +95,10 @@ abstract class Common extends Adapter
      */
     public function fixOrientation()
     {
-        if (!in_array(exif_imagetype($this->source->getInfos()), [IMAGETYPE_JPEG, IMAGETYPE_TIFF_II, IMAGETYPE_TIFF_MM])) {
+        if (!in_array(exif_imagetype($this->source->getInfos()), array(IMAGETYPE_JPEG, IMAGETYPE_TIFF_II, IMAGETYPE_TIFF_MM))) {
             return $this;
         }
-        
+
         if (!extension_loaded('exif')) {
             throw new \RuntimeException('You need to EXIF PHP Extension to use this function');
         }


### PR DESCRIPTION
Other image formats do not support exif and running fixOrientation() on a PNG image generates an error to the image.