### PR TITLE
Supress errors in fixOrientation()

### DIFF
--- a/Adapter/Common.php
+++ b/Adapter/Common.php
@@ -103,9 +103,9 @@ abstract class Common extends Adapter
             throw new \RuntimeException('You need to EXIF PHP Extension to use this function');
         }
 
-        $exif = exif_read_data($this->source->getInfos());
+        $exif = @exif_read_data($this->source->getInfos());
 
-        if (!array_key_exists('Orientation', $exif)) {
+        if ($exif === false || !array_key_exists('Orientation', $exif)) {
             return $this;
         }
 


### PR DESCRIPTION
At the moment when you ->fixOrientation() on pngs or anything other than JPEGs or Tiffs, Gregwar breaks. Not good.

This suppresses errors when it cannot read the exif information.

Fixes #92, #96, #105.