### PR TITLE
Hash generation from relative path instead of absolute

### DIFF
--- a/Image.php
+++ b/Image.php
@@ -430,10 +430,10 @@ class Image
      */
     public function generateHash($type = 'guess', $quality = 80)
     {
-        $inputInfos = $this->source->getInfos();
+        $inputRelativePath = substr($this->source->getInfos(), strlen(getcwd()) + 1);
 
         $datas = array(
-            $inputInfos,
+            $inputRelativePath,
             $this->serializeOperations(),
             $type,
             $quality,


### PR DESCRIPTION
I think that generating hashes from relative path instead of absolute path would allow more usages of this library.

For example, I am working on a website made with Grav CMS, and there's lots of images generation, so first page loads takes lots times (scaling, transforming images etc..). Before deploying in production, I want to ensure that every image has been generated and compiled (to not make the prod verrrry slooww), it does execute `php -S ...` and crawl all the pages with `wget -r ...` then doing a `rsync` the `images/` directory from local to prod.

But because the absolute path is used, the pre-generated images on local won't be used by prod. Prod having as base path something like `/opt/sflx/live/` and the local have something like `/home/dctremblay/Containers/SFLxNG/build/live`. If relative path is used instead of absolute, this trick would work. The commit introduces this fix.

If you have further questions do not hesitate, thank you very much and have a great day !