### PR TITLE
directories are skipped while garbage-collecting

### DIFF
--- a/GarbageCollect.php
+++ b/GarbageCollect.php
@@ -34,7 +34,7 @@ class GarbageCollect
             return false;
         }
 
-        while ($file = readdir($dir)) {
+        while (false !== ($file = readdir($dir))) {
             if ($file == '.' || $file == '..') {
                 continue;
             }


### PR DESCRIPTION
A type safe check is necessary, otherwise folders with the names "0" or "f" would be skipped as they would be interpreted as false in the while condition.

http://php.net/manual/de/function.readdir.php