### PR TITLE
Manage other units for print

### DIFF
--- a/Converter.php
+++ b/Converter.php
@@ -17,7 +17,7 @@ class Converter
    * @param int $resolution in DPI (PPP)
    * @return float
    */
-  static function cmToPixels($cm, $resolution = 150) {
+  static function cmToPixels($cm, $resolution = 96) {
     return $resolution * $cm / 2.54;
   }
 
@@ -27,7 +27,7 @@ class Converter
    * @param int $resolution in DPI (PPP)
    * @return float
    */
-  static function inchToPixel($inch, $resolution = 150) {
+  static function inchToPixel($inch, $resolution = 96) {
     return $resolution * $inch;
   }
 
@@ -37,7 +37,7 @@ class Converter
    * @param int $resolution in DPI (PPP)
    * @return float|int|boolean
    */
-  static function pixelsToCm($pixels, $resolution = 150) {
+  static function pixelsToCm($pixels, $resolution = 96) {
     if($resolution === 0) {
       return false;
     }
@@ -50,7 +50,7 @@ class Converter
    * @param int $resolution in DPI (PPP)
    * @return float|boolean
    */
-  static function pixelsToInch($pixels, $resolution = 150) {
+  static function pixelsToInch($pixels, $resolution = 96) {
     if($resolution === 0) {
       return false;
     }

--- a/Converter.php
+++ b/Converter.php
@@ -54,7 +54,7 @@ class Converter
     if($resolution === 0) {
       return false;
     }
-    return $pixels * $resolution;
+    return $pixels / $resolution;
   }
 
 }

--- a/Converter.php
+++ b/Converter.php
@@ -27,7 +27,7 @@ class Converter
    * @param int $resolution in DPI (PPP)
    * @return float
    */
-  static function inchToPixel($inch, $resolution = 96) {
+  static function inchToPixels($inch, $resolution = 96) {
     return $resolution * $inch;
   }
 

--- a/Converter.php
+++ b/Converter.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Converter resource
+ * User: Clem
+ * Date: 30/05/2019
+ * Time: 21:46
+ */
+
+namespace Gregwar\Image;
+
+class Converter
+{
+
+  /**
+   * Convert Cm to Pixels using resolution in ppp
+   * @param float $cm
+   * @param int $resolution in PPP / DPI
+   * @return float
+   */
+  static function cmToPixels($cm, $resolution = 150) {
+    return $resolution * $cm / 2.54;
+  }
+
+  /**
+   * Convert Inch to Pixels using resolution in ppp
+   * @param float $inch
+   * @param int $resolution in PPP / DPI
+   * @return float
+   */
+  static function inchToPixel($inch, $resolution = 150) {
+    return $resolution * $inch;
+  }
+
+  /**
+   * Convert Pixels to Cm using resolution in ppp
+   * @param $pixels
+   * @param int $resolution in PPP / DPI
+   * @return float|int
+   */
+  static function pixelsToCm($pixels, $resolution = 150) {
+    return $pixels * 2.54 / $resolution;
+  }
+
+  /**
+   * Convert Pixels to Inch using resolution in ppp
+   * @param float $inch
+   * @param int $resolution in PPP / DPI
+   * @return float
+   */
+  static function pixelsToInch($pixels, $resolution = 150) {
+    return $pixels * $resolution;
+  }
+
+}

--- a/Converter.php
+++ b/Converter.php
@@ -12,9 +12,9 @@ class Converter
 {
 
   /**
-   * Convert Cm to Pixels using resolution in ppp
+   * Convert Cm to Pixels using resolution in DPI
    * @param float $cm
-   * @param int $resolution in PPP / DPI
+   * @param int $resolution in DPI (PPP)
    * @return float
    */
   static function cmToPixels($cm, $resolution = 150) {
@@ -22,9 +22,9 @@ class Converter
   }
 
   /**
-   * Convert Inch to Pixels using resolution in ppp
+   * Convert Inch to Pixels using resolution in DPI
    * @param float $inch
-   * @param int $resolution in PPP / DPI
+   * @param int $resolution in DPI (PPP)
    * @return float
    */
   static function inchToPixel($inch, $resolution = 150) {
@@ -32,22 +32,28 @@ class Converter
   }
 
   /**
-   * Convert Pixels to Cm using resolution in ppp
-   * @param $pixels
-   * @param int $resolution in PPP / DPI
-   * @return float|int
+   * Convert Pixels to Cm using resolution in DPI
+   * @param int $pixels
+   * @param int $resolution in DPI (PPP)
+   * @return float|int|boolean
    */
   static function pixelsToCm($pixels, $resolution = 150) {
+    if($resolution === 0) {
+      return false;
+    }
     return $pixels * 2.54 / $resolution;
   }
 
   /**
-   * Convert Pixels to Inch using resolution in ppp
-   * @param float $inch
-   * @param int $resolution in PPP / DPI
-   * @return float
+   * Convert Pixels to Inch using resolution in DPI
+   * @param int $pixels
+   * @param int $resolution in DPI (PPP)
+   * @return float|boolean
    */
   static function pixelsToInch($pixels, $resolution = 150) {
+    if($resolution === 0) {
+      return false;
+    }
     return $pixels * $resolution;
   }
 

--- a/Converter.php
+++ b/Converter.php
@@ -38,7 +38,7 @@ class Converter
    * @return float|int|boolean
    */
   static function pixelsToCm($pixels, $resolution = 96) {
-    if($resolution === 0) {
+    if($resolution == 0) {
       return false;
     }
     return $pixels * 2.54 / $resolution;
@@ -51,7 +51,7 @@ class Converter
    * @return float|boolean
    */
   static function pixelsToInch($pixels, $resolution = 96) {
-    if($resolution === 0) {
+    if($resolution == 0) {
       return false;
     }
     return $pixels / $resolution;

--- a/Image.php
+++ b/Image.php
@@ -756,6 +756,22 @@ class Image
         return 'data:image/'.$mime.';base64,'.base64_encode(file_get_contents($this->cacheFile($type, $quality, true)));
     }
 
+  /**
+   * Return the resolution of resource
+   * @param string $type
+   * @return array|bool|mixed
+   */
+    public function getResolution($type = 'both')
+    {
+      if(function_exists('imageresolution')) {
+        $res = imageresolution ($this->getAdapter()->getResource());
+        if(is_array($res)) {
+          return ($type === 'both') ? $res : (($type === 'Y') ? $res[1] : $res[0]);
+        }
+      }
+      return false;
+    }
+
     /**
      * Creates an instance, usefull for one-line chaining.
      */

--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ The other methods available are:
 
 * `inline($type = 'jpg')`: returns the HTML inlinable base64 string (see `demo/inline.php`)
 
+* `getResolution($type = 'both')`: returns the resolution of picture in DPI. Only available for >= PHP 7. Other $type options: `X` for horizontal resolution, `Y` for vertical resolution, `both` for the both.
+
 You can also create image from scratch using:
 
 ```php
@@ -137,6 +139,20 @@ You can save the image to an explicit file using `save($file, $type = 'jpg', $qu
 ```
 
 You can also get the contents of the image using `get($type = 'jpg', $quality = 80)`, which will return the binary contents of the image
+
+## Converter
+
+Converter allow you to convert centimeters to pixels, inch to pixels... using defined resolution in DPI.
+
+The following static method are available:
+
+* `cmToPixels($cm, $resolution = 96)`: convert centimeters to pixels.
+
+* `inchToPixels($cm, $resolution = 96)`: convert inch to pixels.
+
+* `pixelsToCm($cm, $resolution = 96)`: convert pixels to centimeters.
+
+* `pixelsToInch($cm, $resolution = 96)`: convert pixels to inch.
 
 ## Using cache
 

--- a/composer.json
+++ b/composer.json
@@ -28,5 +28,8 @@
         "psr-0": {
             "Gregwar\\Image": ""
         }
+    },
+    "scripts": {
+        "test": "simple-phpunit --bootstrap vendor/autoload.php tests/ImageTests"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,6 @@
         }
     },
     "scripts": {
-        "test": "simple-phpunit --bootstrap vendor/autoload.php tests/ImageTests"
+        "test": "simple-phpunit --bootstrap vendor/autoload.php"
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -15,6 +15,9 @@
         <testsuite name="Image testing">
             <file>./tests/ImageTests.php</file>
         </testsuite>
+        <testsuite name="Converter testing">
+            <file>./tests/ConverterTests.php</file>
+        </testsuite>
     </testsuites>
 
 </phpunit>

--- a/tests/ConverterTests.php
+++ b/tests/ConverterTests.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Tests for Converter class
+ * User: Clem
+ * Date: 31/05/2019
+ * Time: 09:39
+ */
+
+use \Gregwar\Image\Converter;
+
+class ConverterTests extends \PHPUnit\Framework\TestCase
+{
+  public function testCmToPixels()
+  {
+    // Basic convertion
+    $this->assertEquals(37.795275591, Converter::cmToPixels(1), '', 0.001);
+
+    // 6cm convertion
+    $this->assertEquals(226.771653543, Converter::cmToPixels(6), '', 0.001);
+
+    // 6cm convertion with 300 dpi
+    $this->assertEquals(708.6614173, Converter::cmToPixels(6, 300), '', 0.001);
+  }
+
+  public function testInchToPixels()
+  {
+    // Basic convertion
+    $this->assertEquals(96, Converter::inchToPixels(1));
+
+    // 6inch convertion
+    $this->assertEquals(576, Converter::inchToPixels(6));
+
+    // 6inch convertion with 300 dpi
+    $this->assertEquals(1800, Converter::inchToPixels(6, 300));
+  }
+
+  public function testPixelsToCm()
+  {
+    // Basic convertion
+    $this->assertEquals(0.026458333, Converter::pixelsToCm(1), '', 0.001);
+
+    // 960 pixels convertion
+    $this->assertEquals(25.4, Converter::pixelsToCm(960), '', 0.001);
+
+    // 960 pixels with 300 dpi
+    $this->assertEquals(8.128, Converter::pixelsToCm(960, 300), '', 0.001);
+
+    // 960 pixels with 0 dpi
+    $this->assertEquals(false, Converter::pixelsToCm(960, 0));
+  }
+
+  public function testPixelsToInch()
+  {
+    // Basic convertion
+    $this->assertEquals(0.010416667, Converter::pixelsToInch(1), '', 0.001);
+
+    // 960 pixels convertion
+    $this->assertEquals(10, Converter::pixelsToInch(960), '', 0.001);
+
+    // 960 pixels with 300 dpi
+    $this->assertEquals(3.2, Converter::pixelsToInch(960, 300), '', 0.001);
+
+    // 960 pixels with 0 dpi
+    $this->assertEquals(false, Converter::pixelsToInch(960, 0));
+  }
+}

--- a/tests/ImageTests.php
+++ b/tests/ImageTests.php
@@ -445,7 +445,17 @@ class ImageTests extends \PHPUnit\Framework\TestCase
 
     $image->init();
 
+    // Normal call
     $this->assertEquals(array(96, 96), $image->getResolution());
+
+    // Normal explicit call
+    $this->assertEquals(array(96, 96), $image->getResolution('both'));
+
+    // Call to get X resolution
+    $this->assertEquals(96, $image->getResolution('X'));
+
+    // Call to get Y resolution
+    $this->assertEquals(96, $image->getResolution('Y'));
 
   }
 

--- a/tests/ImageTests.php
+++ b/tests/ImageTests.php
@@ -8,478 +8,504 @@ use Gregwar\Image\ImageColor;
  */
 class ImageTests extends \PHPUnit\Framework\TestCase
 {
-    /**
-     * Testing the basic width & height.
-     */
-    public function testBasics()
-    {
-        $image = $this->open('monalisa.jpg');
+  /**
+   * Testing the basic width & height.
+   */
+  public function testBasics()
+  {
+    $image = $this->open('monalisa.jpg');
 
-        $this->assertSame($image->width(), 771);
-        $this->assertSame($image->height(), 961);
+    $this->assertSame($image->width(), 771);
+    $this->assertSame($image->height(), 961);
+  }
+
+  /**
+   * Testing the resize.
+   */
+  public function testResize()
+  {
+    $image = $this->open('monalisa.jpg');
+
+    $out = $this->output('monalisa_small.jpg');
+    $image
+      ->resize(300, 200)
+      ->save($out);
+
+    $this->assertTrue(file_exists($out));
+
+    $i = imagecreatefromjpeg($out);
+    $this->assertSame(300, imagesx($i));
+    $this->assertSame(200, imagesy($i));
+  }
+
+  /**
+   * Testing the resize %.
+   */
+  public function testResizePercent()
+  {
+    $image = $this->open('monalisa.jpg');
+
+    $out = $this->output('monalisa_small.jpg');
+    $image
+      ->resize('50%')
+      ->save($out);
+
+    $this->assertTrue(file_exists($out));
+
+    $i = imagecreatefromjpeg($out);
+    $this->assertSame(386, imagesx($i));
+    $this->assertSame(481, imagesy($i));
+  }
+
+  /**
+   * Testing to create an image, jpeg, gif and png.
+   */
+  public function testCreateImage()
+  {
+    $black = $this->output('black.jpg');
+
+    Image::create(150, 200)
+      ->fill('black')
+      ->save($black, 100);
+
+    $i = imagecreatefromjpeg($black);
+    $this->assertTrue(file_exists($black));
+    $this->assertSame(150, imagesx($i));
+    $this->assertSame(200, imagesy($i));
+
+    $j = imagecolorat($i, 40, 40);
+    $this->assertSame(0, $j);
+
+    $black = $this->output('black.png');
+    Image::create(150, 200)
+      ->fill('black')
+      ->save($black, 'png');
+
+    $i = imagecreatefrompng($black);
+    $this->assertTrue(file_exists($black));
+    $this->assertSame(150, imagesx($i));
+    $this->assertSame(200, imagesy($i));
+
+    $black = $this->output('black.gif');
+    Image::create(150, 200)
+      ->fill('black')
+      ->save($black, 'gif');
+
+    $i = imagecreatefromgif($black);
+    $this->assertTrue(file_exists($black));
+    $this->assertSame(150, imagesx($i));
+    $this->assertSame(200, imagesy($i));
+  }
+
+  /**
+   * Testing type guess.
+   */
+  public function testGuess()
+  {
+    $image = $this->open('monalisa.jpg');
+    $this->assertSame('jpeg', $image->guessType());
+    $image = $this->open('monalisa.png');
+    $this->assertSame('png', $image->guessType());
+    $image = $this->open('monalisa.gif');
+    $this->assertSame('gif', $image->guessType());
+  }
+
+  public function testDefaultCacheSystem()
+  {
+    $image = $this->open('monalisa.jpg');
+    $this->assertInstanceOf('Gregwar\Cache\Cache', $image->getCacheSystem());
+  }
+
+  public function testCustomCacheSystem()
+  {
+    $image = $this->open('monalisa.jpg');
+    $cache = $this->createMock('Gregwar\Cache\CacheInterface');
+    $image->setCacheSystem($cache);
+    $this->assertTrue($image->getCacheSystem() instanceof Gregwar\Cache\CacheInterface);
+  }
+
+  /**
+   * Testing that caching an image without operations will result
+   * in the original image when force cache is disabled.
+   */
+  public function testNoCache()
+  {
+    $monalisa = __DIR__ . '/files/monalisa.jpg';
+    $image = $this->open('monalisa.jpg')->setForceCache(false);
+    $this->assertSame($monalisa, $image->guess());
+    $image = $this->open('monalisa.jpg');
+    $this->assertNotSame($monalisa, $image->guess());
+    $image = $this->open('monalisa.jpg')->setForceCache(true);
+    $this->assertNotSame($monalisa, $image->guess());
+  }
+
+  public function testActualCache()
+  {
+    $output = $this->open('monalisa.jpg')
+      ->setCacheDir('/magic/path/to/cache/')
+      ->resize(100, 50)->negate()
+      ->guess();
+
+    $this->assertContains('/magic/path/to/cache', $output);
+    $file = str_replace('/magic/path/to', __DIR__ . '/output/', $output);
+    $this->assertTrue(file_exists($file));
+  }
+
+  public function testCacheData()
+  {
+    $output = $this->open('monalisa.jpg')
+      ->resize(300, 200)
+      ->cacheData();
+
+    $jpg = imagecreatefromstring($output);
+    $this->assertSame(300, imagesx($jpg));
+    $this->assertSame(200, imagesy($jpg));
+  }
+
+  /**
+   * Testing using cache.
+   */
+  public function testCache()
+  {
+    $output = $this->open('monalisa.jpg')
+      ->resize(100, 50)->negate()
+      ->guess();
+
+    $this->assertTrue(file_exists($output));
+    $i = imagecreatefromjpeg($output);
+    $this->assertSame(100, imagesx($i));
+    $this->assertSame(50, imagesy($i));
+
+    $output2 = $this->open('monalisa.jpg')
+      ->resize(100, 50)->negate()
+      ->guess();
+
+    $this->assertSame($output, $output2);
+
+    $output3 = $this->open('monalisa.jpg')
+      ->resize(100, 50)->negate()
+      ->png();
+    $this->assertTrue(file_exists($output));
+    $i = imagecreatefrompng($output3);
+    $this->assertSame(100, imagesx($i));
+    $this->assertSame(50, imagesy($i));
+
+    $output4 = $this->open('monalisa.jpg')
+      ->resize(100, 50)->negate()
+      ->gif();
+    $this->assertTrue(file_exists($output));
+    $i = imagecreatefromgif($output4);
+    $this->assertSame(100, imagesx($i));
+    $this->assertSame(50, imagesy($i));
+  }
+
+  /**
+   * Testing Gaussian blur filter.
+   */
+  public function testGaussianBlur()
+  {
+    $image = $this->open('monalisa.jpg')
+      ->gaussianBlur();
+    $secondImage = $this->open('monalisa.jpg')
+      ->gaussianBlur(5);
+
+    $this->assertTrue(file_exists($image));
+    $this->assertTrue(file_exists($secondImage));
+  }
+
+  /**
+   * Testing creating image from data.
+   */
+  public function testData()
+  {
+    $data = file_get_contents(__DIR__ . '/files/monalisa.jpg');
+
+    $output = $this->output('mona.jpg');
+    $image = Image::fromData($data);
+    $image->save($output);
+
+    $this->assertTrue(file_exists($output));
+    $i = imagecreatefromjpeg($output);
+    $this->assertSame(771, imagesx($i));
+    $this->assertSame(961, imagesy($i));
+  }
+
+  /**
+   * Opening an image.
+   */
+  protected function open($file)
+  {
+    $image = Image::open(__DIR__ . '/files/' . $file);
+    $image->setCacheDir(__DIR__ . '/output/cache/');
+    $image->setActualCacheDir(__DIR__ . '/output/cache/');
+
+    return $image;
+  }
+
+  /**
+   * Testing transparent image.
+   */
+  public function testTransparent()
+  {
+    $gif = $this->output('transparent.gif');
+    $i = Image::create(200, 100)
+      ->fill('transparent')
+      ->save($gif, 'gif');
+
+    $this->assertTrue(file_exists($gif));
+    $img = imagecreatefromgif($gif);
+    $this->assertSame(200, imagesx($img));
+    $this->assertSame(100, imagesy($img));
+    $index = imagecolorat($img, 2, 2);
+    $color = imagecolorsforindex($img, $index);
+    $this->assertSame(127, $color['alpha']);
+  }
+
+  public function testNonExistingFile()
+  {
+    $jpg = $this->output('a.jpg');
+    $img = $this->open('non_existing_file.jpg')
+      ->negate();
+    $error = $img->save($jpg);
+
+    $this->assertTrue(file_exists($error));
+  }
+
+  /**
+   * * @expectedException              \UnexpectedValueException
+   */
+  public function testNonExistingFileNoFallback()
+  {
+    Image::open('non_existing_file.jpg')
+      ->useFallback(false)
+      ->save($this->output('a.jpg'));
+  }
+
+  /**
+   * Test that image::save returns the file name.
+   */
+  public function testSaveReturn()
+  {
+    $red = $this->output('red.jpg');
+    $result = Image::create(10, 10)
+      ->fill('red')
+      ->save($red);
+
+    $this->assertSame($red, $result);
+  }
+
+  /**
+   * Testing merge.
+   */
+  public function testMerge()
+  {
+    $out = $this->output('merge.jpg');
+    Image::create(100, 100)
+      ->fill('red')
+      ->merge(Image::create(50, 50)
+        ->fill('black')
+      )
+      ->save($out);
+
+    // Merge file exists
+    $this->assertTrue(file_exists($out));
+
+    // Test that the upper left zone contain a black pixel, and the lower
+    // down contains a red one
+    $img = imagecreatefromjpeg($out);
+    $this->assertColorEquals('black', imagecolorat($img, 5, 12));
+    $this->assertColorEquals('red', imagecolorat($img, 55, 62));
+  }
+
+  /**
+   * Test that dependencies are well generated.
+   */
+  public function testDependencies()
+  {
+    $this->assertSame(array(), Image::create(100, 100)
+      ->getDependencies());
+    $this->assertSame(array(), Image::create(100, 100)
+      ->merge(Image::create(100, 50))
+      ->getDependencies());
+
+    $this->assertSame(array('toto.jpg'), Image::open('toto.jpg')
+      ->merge(Image::create(100, 50))
+      ->getDependencies());
+
+    $this->assertSame(array('toto.jpg', 'titi.jpg'), Image::open('toto.jpg')
+      ->merge(Image::open('titi.jpg'))
+      ->getDependencies());
+
+    $this->assertSame(array('toto.jpg', 'titi.jpg', 'tata.jpg'), Image::open('toto.jpg')
+      ->merge(Image::open('titi.jpg')
+        ->merge(Image::open('tata.jpg')))
+      ->getDependencies());
+  }
+
+  /**
+   * Test that pretty name (for referencing) is well respected.
+   */
+  public function testPrettyName()
+  {
+    $output = $this->open('monalisa.jpg')
+      ->resize(100, 50)->negate()
+      ->setPrettyName('davinci', false)
+      ->guess();
+
+    $this->assertContains('davinci', $output);
+
+    $output2 = $this->open('monalisa.jpg')
+      ->resize(100, 55)->negate()
+      ->setPrettyName('davinci', false)
+      ->guess();
+
+    $this->assertSame($output, $output2);
+
+    $prefix1 = $this->open('monalisa.jpg')
+      ->resize(100, 50)->negate()
+      ->setPrettyName('davinci')
+      ->guess();
+    $prefix2 = $this->open('monalisa.jpg')
+      ->resize(100, 55)->negate()
+      ->setPrettyName('davinci')
+      ->guess();
+
+    $this->assertContains('davinci', $prefix1);
+    $this->assertContains('davinci', $prefix2);
+    $this->assertNotSame($prefix1, $prefix2);
+
+    $transliterator = '\Behat\Transliterator\Transliterator';
+
+    if (class_exists($transliterator)) {
+      $nonLatinName1 = 'ダヴィンチ';
+      $nonLatinOutput1 = $this->open('monalisa.jpg')
+        ->resize(100, 50)->negate()
+        ->setPrettyName($nonLatinName1, false)
+        ->guess();
+
+      $this->assertContains(
+        $transliterator::urlize($transliterator::transliterate($nonLatinName1)),
+        $nonLatinOutput1
+      );
+
+      $nonLatinName2 = 'давинчи';
+      $nonLatinOutput2 = $this->open('monalisa.jpg')
+        ->resize(100, 55)->negate()
+        ->setPrettyName($nonLatinName2)
+        ->guess();
+
+      $this->assertContains(
+        $transliterator::urlize($transliterator::transliterate($nonLatinName2)),
+        $nonLatinOutput2
+      );
     }
+  }
 
-    /**
-     * Testing the resize.
-     */
-    public function testResize()
-    {
-        $image = $this->open('monalisa.jpg');
+  /**
+   * Testing inlining.
+   */
+  public function testInline()
+  {
+    $output = $this->open('monalisa.jpg')
+      ->resize(20, 20)
+      ->inline();
 
-        $out = $this->output('monalisa_small.jpg');
-        $image
-            ->resize(300, 200)
-            ->save($out)
-            ;
+    $this->assertSame(0, strpos($output, 'data:image/jpeg;base64,'));
 
-        $this->assertTrue(file_exists($out));
+    $data = base64_decode(substr($output, 23));
+    $image = imagecreatefromstring($data);
 
-        $i = imagecreatefromjpeg($out);
-        $this->assertSame(300, imagesx($i));
-        $this->assertSame(200, imagesy($i));
+    $this->assertSame(20, imagesx($image));
+    $this->assertSame(20, imagesy($image));
+  }
+
+  /**
+   * Testing that width() can be called after cache
+   */
+  public function testWidthPostCache()
+  {
+    $this->open('monalisa.jpg')
+      ->resize(100, 50)->negate()
+      ->png();
+
+    $dummy2 = $this->open('monalisa.jpg')
+      ->resize(100, 50)->negate();
+    $png = $dummy2->png();
+
+    $i = imagecreatefrompng($png);
+    $this->assertEquals(imagesx($i), $dummy2->width());
+  }
+
+  /**
+   * Test the function getResolution
+   */
+  public function testResolution()
+  {
+    $image = $this->open('monalisa.jpg');
+
+    $image->init();
+
+    $this->assertEquals(array(96, 96), $image->getResolution());
+
+  }
+
+  /**
+   * Asaserting that two colors are equals
+   * (JPG compression is not preserving colors for instance, so we
+   * need a non-strict way to compare it).
+   */
+  protected function assertColorEquals($c1, $c2, $delta = 8)
+  {
+    $c1 = ImageColor::parse($c1);
+    $c2 = ImageColor::parse($c2);
+    list($r1, $g1, $b1) = $this->toRGB($c1);
+    list($r2, $g2, $b2) = $this->toRGB($c2);
+
+    $this->assertLessThan($delta, abs($r1 - $r2));
+    $this->assertLessThan($delta, abs($g1 - $g2));
+    $this->assertLessThan($delta, abs($b1 - $b2));
+  }
+
+  protected function toRGB($color)
+  {
+    $b = $color & 0xff;
+    $g = ($color >> 8) & 0xff;
+    $r = ($color >> 16) & 0xff;
+
+    return array($r, $g, $b);
+  }
+
+  /**
+   * Outputing an image to a file.
+   */
+  protected function output($file)
+  {
+    return __DIR__ . '/output/' . $file;
+  }
+
+  /**
+   * Reinitialize the output dir.
+   */
+  public function setUp()
+  {
+    $dir = $this->output('');
+   // `rm -rf $dir`;    // This line is replaced by follow because doesn't work on Windows system
+    ImageTests::delTree($dir);
+    mkdir($dir);
+    mkdir($this->output('cache'));
+  }
+
+  /**
+   * Del recursively a tree folder
+   * @param $dir
+   * @return bool
+   */
+  public static function delTree($dir)
+  {
+    $files = array_diff(scandir($dir), array('.', '..'));
+    foreach ($files as $file) {
+      (is_dir("$dir/$file")) ? ImageTests::delTree("$dir/$file") : unlink("$dir/$file");
     }
-
-    /**
-     * Testing the resize %.
-     */
-    public function testResizePercent()
-    {
-        $image = $this->open('monalisa.jpg');
-
-        $out = $this->output('monalisa_small.jpg');
-        $image
-            ->resize('50%')
-            ->save($out)
-            ;
-
-        $this->assertTrue(file_exists($out));
-
-        $i = imagecreatefromjpeg($out);
-        $this->assertSame(386, imagesx($i));
-        $this->assertSame(481, imagesy($i));
-    }
-
-    /**
-     * Testing to create an image, jpeg, gif and png.
-     */
-    public function testCreateImage()
-    {
-        $black = $this->output('black.jpg');
-
-        Image::create(150, 200)
-            ->fill('black')
-            ->save($black, 100);
-
-        $i = imagecreatefromjpeg($black);
-        $this->assertTrue(file_exists($black));
-        $this->assertSame(150, imagesx($i));
-        $this->assertSame(200, imagesy($i));
-
-        $j = imagecolorat($i, 40, 40);
-        $this->assertSame(0, $j);
-
-        $black = $this->output('black.png');
-        Image::create(150, 200)
-            ->fill('black')
-            ->save($black, 'png');
-
-        $i = imagecreatefrompng($black);
-        $this->assertTrue(file_exists($black));
-        $this->assertSame(150, imagesx($i));
-        $this->assertSame(200, imagesy($i));
-
-        $black = $this->output('black.gif');
-        Image::create(150, 200)
-            ->fill('black')
-            ->save($black, 'gif');
-
-        $i = imagecreatefromgif($black);
-        $this->assertTrue(file_exists($black));
-        $this->assertSame(150, imagesx($i));
-        $this->assertSame(200, imagesy($i));
-    }
-
-    /**
-     * Testing type guess.
-     */
-    public function testGuess()
-    {
-        $image = $this->open('monalisa.jpg');
-        $this->assertSame('jpeg', $image->guessType());
-        $image = $this->open('monalisa.png');
-        $this->assertSame('png', $image->guessType());
-        $image = $this->open('monalisa.gif');
-        $this->assertSame('gif', $image->guessType());
-    }
-
-    public function testDefaultCacheSystem()
-    {
-        $image = $this->open('monalisa.jpg');
-        $this->assertInstanceOf('Gregwar\Cache\Cache', $image->getCacheSystem());
-    }
-
-    public function testCustomCacheSystem()
-    {
-        $image = $this->open('monalisa.jpg');
-        $cache = $this->createMock('Gregwar\Cache\CacheInterface');
-        $image->setCacheSystem($cache);
-        $this->assertTrue($image->getCacheSystem() instanceof Gregwar\Cache\CacheInterface);
-    }
-
-    /**
-     * Testing that caching an image without operations will result
-     * in the original image when force cache is disabled.
-     */
-    public function testNoCache()
-    {
-        $monalisa = __DIR__.'/files/monalisa.jpg';
-        $image = $this->open('monalisa.jpg')->setForceCache(false);
-        $this->assertSame($monalisa, $image->guess());
-        $image = $this->open('monalisa.jpg');
-        $this->assertNotSame($monalisa, $image->guess());
-        $image = $this->open('monalisa.jpg')->setForceCache(true);
-        $this->assertNotSame($monalisa, $image->guess());
-    }
-
-    public function testActualCache()
-    {
-        $output = $this->open('monalisa.jpg')
-            ->setCacheDir('/magic/path/to/cache/')
-            ->resize(100, 50)->negate()
-            ->guess();
-
-        $this->assertContains('/magic/path/to/cache', $output);
-        $file = str_replace('/magic/path/to', __DIR__.'/output/', $output);
-        $this->assertTrue(file_exists($file));
-    }
-
-    public function testCacheData()
-    {
-        $output = $this->open('monalisa.jpg')
-            ->resize(300, 200)
-            ->cacheData();
-
-        $jpg = imagecreatefromstring($output);
-        $this->assertSame(300, imagesx($jpg));
-        $this->assertSame(200, imagesy($jpg));
-    }
-
-    /**
-     * Testing using cache.
-     */
-    public function testCache()
-    {
-        $output = $this->open('monalisa.jpg')
-            ->resize(100, 50)->negate()
-            ->guess();
-
-        $this->assertTrue(file_exists($output));
-        $i = imagecreatefromjpeg($output);
-        $this->assertSame(100, imagesx($i));
-        $this->assertSame(50, imagesy($i));
-
-        $output2 = $this->open('monalisa.jpg')
-            ->resize(100, 50)->negate()
-            ->guess();
-
-        $this->assertSame($output, $output2);
-
-        $output3 = $this->open('monalisa.jpg')
-            ->resize(100, 50)->negate()
-            ->png();
-        $this->assertTrue(file_exists($output));
-        $i = imagecreatefrompng($output3);
-        $this->assertSame(100, imagesx($i));
-        $this->assertSame(50, imagesy($i));
-
-        $output4 = $this->open('monalisa.jpg')
-            ->resize(100, 50)->negate()
-            ->gif();
-        $this->assertTrue(file_exists($output));
-        $i = imagecreatefromgif($output4);
-        $this->assertSame(100, imagesx($i));
-        $this->assertSame(50, imagesy($i));
-    }
-
-    /**
-     * Testing Gaussian blur filter.
-     */
-    public function testGaussianBlur()
-    {
-        $image = $this->open('monalisa.jpg')
-            ->gaussianBlur();
-        $secondImage = $this->open('monalisa.jpg')
-            ->gaussianBlur(5);
-
-        $this->assertTrue(file_exists($image));
-        $this->assertTrue(file_exists($secondImage));
-    }
-
-    /**
-     * Testing creating image from data.
-     */
-    public function testData()
-    {
-        $data = file_get_contents(__DIR__.'/files/monalisa.jpg');
-
-        $output = $this->output('mona.jpg');
-        $image = Image::fromData($data);
-        $image->save($output);
-
-        $this->assertTrue(file_exists($output));
-        $i = imagecreatefromjpeg($output);
-        $this->assertSame(771, imagesx($i));
-        $this->assertSame(961, imagesy($i));
-    }
-
-    /**
-     * Opening an image.
-     */
-    protected function open($file)
-    {
-        $image = Image::open(__DIR__.'/files/'.$file);
-        $image->setCacheDir(__DIR__.'/output/cache/');
-        $image->setActualCacheDir(__DIR__.'/output/cache/');
-
-        return $image;
-    }
-
-    /**
-     * Testing transparent image.
-     */
-    public function testTransparent()
-    {
-        $gif = $this->output('transparent.gif');
-        $i = Image::create(200, 100)
-            ->fill('transparent')
-            ->save($gif, 'gif');
-
-        $this->assertTrue(file_exists($gif));
-        $img = imagecreatefromgif($gif);
-        $this->assertSame(200, imagesx($img));
-        $this->assertSame(100, imagesy($img));
-        $index = imagecolorat($img, 2, 2);
-        $color = imagecolorsforindex($img, $index);
-        $this->assertSame(127, $color['alpha']);
-    }
-
-    public function testNonExistingFile()
-    {
-        $jpg = $this->output('a.jpg');
-        $img = $this->open('non_existing_file.jpg')
-            ->negate();
-        $error = $img->save($jpg);
-
-        $this->assertTrue(file_exists($error));
-    }
-
-    /**
-     * * @expectedException              \UnexpectedValueException
-     */
-    public function testNonExistingFileNoFallback()
-    {
-        Image::open('non_existing_file.jpg')
-            ->useFallback(false)
-            ->save($this->output('a.jpg'));
-    }
-
-    /**
-     * Test that image::save returns the file name.
-     */
-    public function testSaveReturn()
-    {
-        $red = $this->output('red.jpg');
-        $result = Image::create(10, 10)
-            ->fill('red')
-            ->save($red);
-
-        $this->assertSame($red, $result);
-    }
-
-    /**
-     * Testing merge.
-     */
-    public function testMerge()
-    {
-        $out = $this->output('merge.jpg');
-        Image::create(100, 100)
-            ->fill('red')
-            ->merge(Image::create(50, 50)
-                ->fill('black')
-            )
-            ->save($out);
-
-        // Merge file exists
-        $this->assertTrue(file_exists($out));
-
-        // Test that the upper left zone contain a black pixel, and the lower
-        // down contains a red one
-        $img = imagecreatefromjpeg($out);
-        $this->assertColorEquals('black', imagecolorat($img, 5, 12));
-        $this->assertColorEquals('red', imagecolorat($img, 55, 62));
-    }
-
-    /**
-     * Test that dependencies are well generated.
-     */
-    public function testDependencies()
-    {
-        $this->assertSame(array(), Image::create(100, 100)
-            ->getDependencies());
-        $this->assertSame(array(), Image::create(100, 100)
-            ->merge(Image::create(100, 50))
-            ->getDependencies());
-
-        $this->assertSame(array('toto.jpg'), Image::open('toto.jpg')
-            ->merge(Image::create(100, 50))
-            ->getDependencies());
-
-        $this->assertSame(array('toto.jpg', 'titi.jpg'), Image::open('toto.jpg')
-            ->merge(Image::open('titi.jpg'))
-            ->getDependencies());
-
-        $this->assertSame(array('toto.jpg', 'titi.jpg', 'tata.jpg'), Image::open('toto.jpg')
-            ->merge(Image::open('titi.jpg')
-                    ->merge(Image::open('tata.jpg')))
-            ->getDependencies());
-    }
-
-    /**
-     * Test that pretty name (for referencing) is well respected.
-     */
-    public function testPrettyName()
-    {
-        $output = $this->open('monalisa.jpg')
-            ->resize(100, 50)->negate()
-            ->setPrettyName('davinci', false)
-            ->guess();
-
-        $this->assertContains('davinci', $output);
-
-        $output2 = $this->open('monalisa.jpg')
-            ->resize(100, 55)->negate()
-            ->setPrettyName('davinci', false)
-            ->guess();
-
-        $this->assertSame($output, $output2);
-
-        $prefix1 = $this->open('monalisa.jpg')
-            ->resize(100, 50)->negate()
-            ->setPrettyName('davinci')
-            ->guess();
-        $prefix2 = $this->open('monalisa.jpg')
-            ->resize(100, 55)->negate()
-            ->setPrettyName('davinci')
-            ->guess();
-
-        $this->assertContains('davinci', $prefix1);
-        $this->assertContains('davinci', $prefix2);
-        $this->assertNotSame($prefix1, $prefix2);
-
-        $transliterator = '\Behat\Transliterator\Transliterator';
-
-        if (class_exists($transliterator)) {
-            $nonLatinName1 = 'ダヴィンチ';
-            $nonLatinOutput1 = $this->open('monalisa.jpg')
-                ->resize(100, 50)->negate()
-                ->setPrettyName($nonLatinName1, false)
-                ->guess();
-
-            $this->assertContains(
-                $transliterator::urlize($transliterator::transliterate($nonLatinName1)),
-                $nonLatinOutput1
-            );
-
-            $nonLatinName2 = 'давинчи';
-            $nonLatinOutput2 = $this->open('monalisa.jpg')
-                ->resize(100, 55)->negate()
-                ->setPrettyName($nonLatinName2)
-                ->guess();
-
-            $this->assertContains(
-                $transliterator::urlize($transliterator::transliterate($nonLatinName2)),
-                $nonLatinOutput2
-            );
-        }
-    }
-
-    /**
-     * Testing inlining.
-     */
-    public function testInline()
-    {
-        $output = $this->open('monalisa.jpg')
-            ->resize(20, 20)
-            ->inline();
-
-        $this->assertSame(0, strpos($output, 'data:image/jpeg;base64,'));
-
-        $data = base64_decode(substr($output, 23));
-        $image = imagecreatefromstring($data);
-
-        $this->assertSame(20, imagesx($image));
-        $this->assertSame(20, imagesy($image));
-    }
-
-    /**
-     * Testing that width() can be called after cache
-     */
-    public function testWidthPostCache()
-    {
-        $this->open('monalisa.jpg')
-            ->resize(100, 50)->negate()
-            ->png();
-        
-        $dummy2 = $this->open('monalisa.jpg')
-            ->resize(100, 50)->negate();
-        $png = $dummy2->png();
-
-        $i = imagecreatefrompng($png);
-        $this->assertEquals(imagesx($i), $dummy2->width());
-    }
-
-    /**
-     * Asaserting that two colors are equals
-     * (JPG compression is not preserving colors for instance, so we
-     * need a non-strict way to compare it).
-     */
-    protected function assertColorEquals($c1, $c2, $delta = 8)
-    {
-        $c1 = ImageColor::parse($c1);
-        $c2 = ImageColor::parse($c2);
-        list($r1, $g1, $b1) = $this->toRGB($c1);
-        list($r2, $g2, $b2) = $this->toRGB($c2);
-
-        $this->assertLessThan($delta, abs($r1 - $r2));
-        $this->assertLessThan($delta, abs($g1 - $g2));
-        $this->assertLessThan($delta, abs($b1 - $b2));
-    }
-
-    protected function toRGB($color)
-    {
-        $b = $color & 0xff;
-        $g = ($color >> 8) & 0xff;
-        $r = ($color >> 16) & 0xff;
-
-        return array($r, $g, $b);
-    }
-
-    /**
-     * Outputing an image to a file.
-     */
-    protected function output($file)
-    {
-        return __DIR__.'/output/'.$file;
-    }
-
-    /**
-     * Reinitialize the output dir.
-     */
-    public function setUp()
-    {
-        $dir = $this->output('');
-        `rm -rf $dir`;
-        mkdir($dir);
-        mkdir($this->output('cache'));
-    }
+    return rmdir($dir);
+  }
 }


### PR DESCRIPTION
I propose this work in order to:
  - add method `getResolution` to `Image` class. This method return the resolution of resource.
  - add class `Converter` in order to convert centimeters to pixels, inch to pixels...

It allow the user to manage picture for print according the resolution.

Example:

```
    $image = $this->open('monalisa.jpg');
    $image->init();

    $resolution = $image->getResolution();
    
    // Save the picture for 6 cm print
    $image
        ->cropResize(Converter::cmToPixels($resolution[0], 6), Converter::cmToPixels($resolution[1], 6))
        ->save($pathToJpgFile);
```

Tests and Readme of project is updated.
