### PR TITLE
Extract applyExifOrientation out of fixOrientation

### DIFF
--- a/Adapter/Common.php
+++ b/Adapter/Common.php
@@ -91,11 +91,15 @@ abstract class Common extends Adapter
     }
 
     /**
-     * Fix orientation using Exif informations.
+     * Read exif rotation from file and apply it.
      */
     public function fixOrientation()
     {
-        if (!in_array(exif_imagetype($this->source->getInfos()), array(IMAGETYPE_JPEG, IMAGETYPE_TIFF_II, IMAGETYPE_TIFF_MM))) {
+        if (!in_array(exif_imagetype($this->source->getInfos()), array(
+            IMAGETYPE_JPEG,
+            IMAGETYPE_TIFF_II,
+            IMAGETYPE_TIFF_MM,
+        ))) {
             return $this;
         }
 
@@ -109,7 +113,15 @@ abstract class Common extends Adapter
             return $this;
         }
 
-        switch ($exif['Orientation']) {
+        return $this->applyExifOrientation($exif['Orientation']);
+    }
+
+    /**
+     * Apply orientation using Exif orientation value.
+     */
+    public function applyExifOrientation($exif_orienation)
+    {
+        switch ($exif_orienation) {
             case 1:
                 break;
 

--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ The other methods available are:
 
 * `fixOrientation()`: return the image rotated and flipped using image exif information 
 
+* `applyExifOrientation(int $exif_rotation_value)`: return the image rotated and flipped using an exif rotation value 
+
 * `html($title = '', $type = 'jpg')`: return the `<img ... />` tag with the cache image
 
 * `flip($flipVertical, $flipHorizontal)`: flips the image in the given directions. Both params are boolean and at least one must be true.


### PR DESCRIPTION
Taking out the bit that actually applies the rotation and putting it in a separate method enables the user to run applyExifOrientation by itself to override the exif tag.