### PR TITLE
More robust error handling

### DIFF
--- a/Adapter/Common.php
+++ b/Adapter/Common.php
@@ -107,7 +107,11 @@ abstract class Common extends Adapter
             throw new \RuntimeException('You need to EXIF PHP Extension to use this function');
         }
 
-        $exif = @exif_read_data($this->source->getInfos());
+        try {
+            $exif = @exif_read_data($this->source->getInfos());
+        } catch (\Exception $e) {
+            $exif = false;
+        }
 
         if ($exif === false || !array_key_exists('Orientation', $exif)) {
             return $this;


### PR DESCRIPTION
If using custom error handling, the @ error suppression may get ignored and errors in exif_read_data throw an Exception.