### PR TITLE
Added missing quality parameter to webp method

### DIFF
--- a/Image.php
+++ b/Image.php
@@ -573,11 +573,11 @@ class Image
     }
 
     /**
-     * Generates and output a png cached file.
+     * Generates and output a webp cached file.
      */
-    public function webp()
+    public function webp($quality = 80)
     {
-        return $this->cacheFile('webp');
+        return $this->cacheFile('webp', $quality);
     }
 
     /**


### PR DESCRIPTION
This parameter is needed to control the quality of the WebP image in the webp twig image function.

Example with 50% quality:
```Twig
{{ web_image(image).webp(50) }}
```