### PR TITLE
AVIF support

### DIFF
--- a/Adapter/AdapterInterface.php
+++ b/Adapter/AdapterInterface.php
@@ -85,6 +85,13 @@ interface AdapterInterface
     public function saveWebp($file, $quality);
 
     /**
+     * Save the image as a AVIF.
+     *
+     * @return $this
+     */
+    public function saveAvif($file, $quality);
+
+    /**
      * Save the image as a jpeg.
      *
      * @return $this

--- a/Adapter/Common.php
+++ b/Adapter/Common.php
@@ -193,6 +193,8 @@ abstract class Common extends Adapter
 
     abstract protected function openWebp($file);
 
+    abstract protected function openAvif($file);
+
     /**
      * Creates an image.
      */
@@ -231,6 +233,10 @@ abstract class Common extends Adapter
 
         if ($type == 'webp') {
             $this->openWebp($file);
+        }
+
+        if ($type == 'avif') {
+            $this->openAvif($file);
         }
 
         if (false === $this->resource) {

--- a/Adapter/GD.php
+++ b/Adapter/GD.php
@@ -5,8 +5,14 @@ namespace Gregwar\Image\Adapter;
 use Gregwar\Image\Image;
 use Gregwar\Image\ImageColor;
 
+// Add IMG_AVIF constant for PHP versions below 8.1
+defined('IMG_AVIF') or define('IMG_AVIF', 256);
+
 class GD extends Common
 {
+    /**
+     * GD image types supported by this adapter.
+     */
     public static $gdTypes = array(
         'jpeg'  => \IMG_JPG,
         'gif'   => \IMG_GIF,
@@ -677,6 +683,7 @@ class GD extends Common
 
     /**
      * Does this adapter supports type ?
+     * Returns true if checked type is supported by the PHP/GD build and this adapter.
      */
     protected function supports($type)
     {

--- a/Adapter/GD.php
+++ b/Adapter/GD.php
@@ -11,7 +11,8 @@ class GD extends Common
         'jpeg'  => \IMG_JPG,
         'gif'   => \IMG_GIF,
         'png'   => \IMG_PNG,
-        'webp'  => \IMG_WEBP
+        'webp'  => \IMG_WEBP,
+        'avif'  => \IMG_AVIF
     );
 
     protected function loadResource($resource)
@@ -597,6 +598,16 @@ class GD extends Common
     /**
      * {@inheritdoc}
      */
+    public function saveAvif($file, $quality)
+    {
+        imageavif($this->resource, $file, $quality);
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function saveJpeg($file, $quality)
     {
         imagejpeg($this->resource, $file, $quality);
@@ -647,6 +658,18 @@ class GD extends Common
     {
         if (file_exists($file) && filesize($file)) {
             $this->resource = @imagecreatefromwebp($file);
+        } else {
+            $this->resource = false;
+        }
+    }
+
+    /**
+     * Try to open the file using AVIF.
+     */
+    protected function openAvif($file)
+    {
+        if (file_exists($file) && filesize($file)) {
+            $this->resource = @imagecreatefromavif($file);
         } else {
             $this->resource = false;
         }

--- a/Image.php
+++ b/Image.php
@@ -586,7 +586,7 @@ class Image
     /**
      * Generates and output a webp cached file.
      */
-    public function avif($quality = 30)
+    public function avif($quality = 80)
     {
         return $this->cacheFile('avif', $quality);
     }

--- a/Image.php
+++ b/Image.php
@@ -14,6 +14,8 @@ use Gregwar\Image\Exceptions\GenerationError;
  * @method Image saveGif($file)
  * @method Image savePng($file)
  * @method Image saveJpeg($file, $quality)
+ * @method Image saveWebP($file, $quality)
+ * @method Image saveAvif($file, $quality)
  * @method Image resize($width = null, $height = null, $background = 'transparent', $force = false, $rescale = false, $crop = false)
  * @method Image forceResize($width = null, $height = null, $background = 'transparent')
  * @method Image scaleResize($width = null, $height = null, $background = 'transparent', $crop = false)
@@ -94,6 +96,7 @@ class Image
         'jpg'   => 'jpeg',
         'jpeg'  => 'jpeg',
         'webp'  => 'webp',
+        'avif'  => 'avif',
         'png'   => 'png',
         'gif'   => 'gif',
     );
@@ -581,6 +584,14 @@ class Image
     }
 
     /**
+     * Generates and output a webp cached file.
+     */
+    public function avif($quality = 30)
+    {
+        return $this->cacheFile('avif', $quality);
+    }
+
+    /**
      * Generates and output an image using the same type as input.
      */
     public function guess($quality = 80)
@@ -685,6 +696,10 @@ class Image
 
             if ($type == 'webp') {
                 $success = $this->getAdapter()->saveWebP($file, $quality);
+            }
+
+            if ($type == 'avif') {
+                $success = $this->getAdapter()->saveAvif($file, $quality);
             }
 
             if (!$success) {

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Once the cache directory configured, you can call the following methods:
 
 * `webp($quality = 80)`: lookup or create a WebP cache file on-the-fly
 
-* `avif($quality = 30)`: lookup or create a AVIF cache file on-the-fly (**PHP 8.1 or greater required**)
+* `avif($quality = 80)`: lookup or create a AVIF cache file on-the-fly (**PHP 8.1 or greater required**)
 
 * `gif()`: lookup or create a GIF cache file on-the-fly
 

--- a/README.md
+++ b/README.md
@@ -148,11 +148,15 @@ array. This operation array, the name, type and modification time of file are ha
 
 Once the cache directory configured, you can call the following methods:
 
-* `jpeg($quality = 80)`: lookup or create a jpeg cache file on-the-fly
+* `jpeg($quality = 80)`: lookup or create a JPEG cache file on-the-fly
 
-* `gif()`: lookup or create a gif cache file on-the-fly
+* `webp($quality = 80)`: lookup or create a WebP cache file on-the-fly
 
-* `png()`: lookup or create a png cache file on-the-fly
+* `avif($quality = 30)`: lookup or create a AVIF cache file on-the-fly (**PHP 8.1 or greater required**)
+
+* `gif()`: lookup or create a GIF cache file on-the-fly
+
+* `png()`: lookup or create a PNG cache file on-the-fly
 
 * `guess($quality = 80)`: guesses the type (use the same as input) and lookup or create a
   cache file on-the-fly

--- a/Source/File.php
+++ b/Source/File.php
@@ -47,6 +47,10 @@ class File extends Source
                 if ($type == IMAGETYPE_WEBP) {
                     return 'webp';
                 }
+
+                if ($type == IMAGETYPE_AVIF) {
+                    return 'avif';
+                }
             }
         }
 

--- a/Source/File.php
+++ b/Source/File.php
@@ -48,7 +48,7 @@ class File extends Source
                     return 'webp';
                 }
 
-                if ($type == IMAGETYPE_AVIF) {
+                if (defined('IMAGETYPE_AVIF') && $type == IMAGETYPE_AVIF) {
                     return 'avif';
                 }
             }


### PR DESCRIPTION
Beginning with PHP 8.1, the GD image library added support for AVIF images.

This pull request adds support for AVIF images to this library.