### PR TITLE
fix: resolve Creation of dynamic property in php8.2

### DIFF
--- a/Exceptions/GenerationError.php
+++ b/Exceptions/GenerationError.php
@@ -4,6 +4,11 @@ namespace Gregwar\Image\Exceptions;
 
 class GenerationError extends \Exception
 {
+    /**
+     * @var mixed
+     */
+    private $newNewFile;
+
     public function __construct($newNewFile)
     {
         $this->newNewFile = $newNewFile;


### PR DESCRIPTION
When using the GenerationError exception class in PHP versions greater than 8.2, a deprecation error occurs due to the creation of a dynamic property Gregwar\Image\Exceptions\GenerationError::$newNewFile. This error can be resolved by explicitly adding the $newNewFile property to the GenerationError class.


Changes:
- **Added dynamic property:** $newNewFile has been added to the GenerationError class to address the deprecation error.
